### PR TITLE
Migration to GitHub Actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+
+    steps:
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install -U pip wheel
+          pip install -r requirements.txt
+
+      - name: flake8 lint
+        run: flake8 --exclude=pyenv,pyenv3 --ignore=E501
+
+      - name: Run tests with pytest
+        run: py.test

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 IATI Website Tests
 ==================
 
+.. image:: https://github.com/IATI/IATI-Website-Tests/workflows/CI/badge.svg
+    :target: https://github.com/IATI/IATI-Website-Tests/actions
+
 .. image:: https://travis-ci.org/IATI/IATI-Website-Tests.svg?branch=master
     :target: https://travis-ci.org/IATI/IATI-Website-Tests
 .. image:: https://requires.io/github/IATI/IATI-Website-Tests/requirements.svg?branch=master


### PR DESCRIPTION
## Summary
- TravisCI.org is read-only after 31 Dec 2020 so we're migrating to GitHub Actions to run the CI tests/linting.﻿
